### PR TITLE
Fixed null issue in wpNavMenuClassChange

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -332,10 +332,12 @@ window.wpNavMenuClassChange = function( page, url ) {
 
 	if ( page.wpOpenMenu ) {
 		const currentMenu = document.querySelector( '#' + page.wpOpenMenu );
-		currentMenu.classList.remove( 'wp-not-current-submenu' );
-		currentMenu.classList.add( 'wp-has-current-submenu' );
-		currentMenu.classList.add( 'wp-menu-open' );
-		currentMenu.classList.add( 'current' );
+		if ( currentMenu ) {
+			currentMenu.classList.remove( 'wp-not-current-submenu' );
+			currentMenu.classList.add( 'wp-has-current-submenu' );
+			currentMenu.classList.add( 'wp-menu-open' );
+			currentMenu.classList.add( 'current' );
+		}
 	}
 
 	const wpWrap = document.querySelector( '#wpwrap' );


### PR DESCRIPTION
Fixes #

I got an error message on the WC Dashboard admin page when I try to customize WC admin menu item with [Cusmin](https://cusmin.com). This is the error message that I get on the WC Dashboard page, it breaks the page.

TypeError: “c is null” wpNavMenuClassChange

The error is thrown in this file
/wp-content/plugins/woocommerce/packages/woocommerce-admin/dist/app/index.min.js?ver=1.2.3
on line 2:58145

This is the particular code:

`var c=document.querySelector("#"+e.wpOpenMenu);c.classList.remove("wp-not-current-submenu")`

It fails on c.classList where c is null

The problem appears when I try to change the menu item name or add a custom icon with Cusmin. It looks like that Woocommerce is listening for these changes and does not handle this particular case correctly, when a change event is triggered outside of WC.
### Screenshots
https://prnt.sc/sutoxi
https://prnt.sc/sutsbh